### PR TITLE
Bump semantic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-quality-logger",
-  "version": "1.1.2",
+  "version": "1.10.1",
   "description": "Automatically sets YouTube videos to the highest quality.",
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Auto High-Quality YouTube",
-  "version": "1.1.2",
+  "version": "1.10.1",
   "description": "Automatically sets YouTube videos to the highest quality.",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Chrome webstore is being mad because when I switched to semantic versioning the version technically wasn't higher than the previous version

![image](https://github.com/DanielF737/auto-max-quality-youtube/assets/38881572/48f212fd-a960-44cf-a3cc-345203923574)
